### PR TITLE
Fix: Correct usage of withUnsafeBytes in update(data:)

### DIFF
--- a/Sources/BLAKE3/BLAKE3.swift
+++ b/Sources/BLAKE3/BLAKE3.swift
@@ -53,7 +53,7 @@ public final class BLAKE3 {
     /// hasher.update(data: data)
     /// ```
     public func update(data: Data) {
-        update(bytes: data.withUnsafeBytes { $0 })
+        data.withUnsafeBytes { update(bytes: $0 )  }
     }
 
     /// Finalize the hasher and return the hash as a buffer of bytes.


### PR DESCRIPTION
The previous implementation could lead to a dangling pointer issue. The pointer obtained from data.withUnsafeBytes is only guaranteed to be valid for the duration of its closure. By passing the pointer out of the closure to the update(bytes:) function, we risked memory corruption or a crash.

This fix moves the call to update(bytes:) inside the withUnsafeBytes closure, ensuring the pointer is always valid when accessed.

After this fix, we can get the exactly same result with `b3sum`:

```swift
import Foundation
import BLAKE3

extension Data {
    var hexEncodedString: String {
        return map { String(format: "%02hhx", $0) }.joined()
    }
}

func testBlake3() {
    let data = "a".data(using: .utf8)!
    
    var hasher = BLAKE3()
    hasher.update(data: data )
    var hash = hasher.finalizeData()
    print(hash.hexEncodedString)
    
}

testBlake3()
```

output:
```
17762fddd969a453925d65717ac3eea21320b66b54342fde15128d6caf21215f
```

The `b3sum`'s output:
```
$ echo -n 'a' | b3sum
17762fddd969a453925d65717ac3eea21320b66b54342fde15128d6caf21215f  -
```